### PR TITLE
Add aws-sdk as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {},
   "devDependencies": {},
   "dependencies": {
+    "aws-sdk": "^2.2.33",
     "bluebird": "^3.0.6"
   },
   "bugs": {


### PR DESCRIPTION
When running `sls dash deploy` the following error is thrown:

```
Error: Cannot find module 'aws-sdk'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at module.exports (/Users/luigi/serverless/node_modules/serverless-plugin-sns/index.js:5:22)
    at Serverless._loadPlugins (/usr/local/lib/node_modules/serverless/lib/Serverless.js:251:25)
    at new Serverless (/usr/local/lib/node_modules/serverless/lib/Serverless.js:82:37)
    at Object.<anonymous> (/usr/local/lib/node_modules/serverless/bin/serverless:11:19)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:139:18)
    at node.js:999:3
```

This should fix the issue.
