### PR TITLE
Fix project name resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,9 +114,8 @@ module.exports = function(SPlugin) {
          * @return string
          */
         _getTopicNameBySettings (settings) {
-            var projectPath = this.S.config.projectPath.split('/');
             var replacements = [];
-            replacements['project'] = projectPath[(projectPath.length - 1)];
+            replacements['project'] = this.S.state.meta.variables.project;
             replacements['stage'] = this.stage;
             replacements['component'] = settings.deployed.component;
             replacements['module'] = settings.deployed.module;


### PR DESCRIPTION
The last "piece" of the project path is different from the project name for my project.
This should grab the correct project name.
