### PR TITLE
Fix subscription when topic exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = function(SPlugin) {
                 }
 
                 var topicCreatePromises = [];
-                
+
                 for (var i in this.topics) {
                     if (!topicList[i]) {
                         console.log('topic ' + i + ' does not exist. it will be created now');
@@ -207,9 +207,7 @@ module.exports = function(SPlugin) {
                 if (topicCreatePromises.length > 0) {
                     return BbPromise.all(topicCreatePromises);
                 } else {
-                    return new BbPromise(function(resolve, reject) {
-                        return resolve(evt);
-                    });                    
+                    return BbPromise.resolve();
                 }
             }.bind(this));
         }


### PR DESCRIPTION
The [Promise](https://github.com/martinlindenberg/serverless-plugin-sns/blob/0817fa7fb84f6ddaba8efddcecb2407bcffa8834/index.js#L210-L212) is rejected when the topic exists because `evt` is not defined.
When [this happens](https://github.com/martinlindenberg/serverless-plugin-sns/blob/0817fa7fb84f6ddaba8efddcecb2407bcffa8834/index.js#L81-L83) the function is not subscribed to the topic.
