### PR TITLE
missing comma?

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ module.exports = function(S) {
          * @return void
          */
         _initAws (region) {
-            let _this = this
+            let _this = this,
                 credentials = S.getProvider('aws').getCredentials(_this.stage, region);;
 
             _this.sns = new AWS.SNS({


### PR DESCRIPTION
Hi - the plugin wouldn't run on my end Node 5.2, serverless 5.1.. I had to pop in and add this comma, fwiw was getting the following error:

```
/usr/local/lib/node_modules/serverless/node_modules/bluebird/js/release/async.js:49
        fn = function () { throw arg; };
                           ^

ReferenceError: credentials is not defined
    at ServerlessPluginSNS._initAws (/Users/srg/Documents/workspace/Cahoots-Server/cahoots51/node_modules/serverless-plugin-sns/index.js:239:26)
    at ServerlessPluginSNS._manageSNS (/Users/srg/Documents/workspace/Cahoots-Server/cahoots51/node_modules/serverless-plugin-sns/index.js:63:19)
    at /Users/srg/Documents/workspace/Cahoots-Server/cahoots51/node_modules/serverless-plugin-sns/index.js:44:27
    at ServerlessPluginSNS._addSNSAfterDeploy (/Users/srg/Documents/workspace/Cahoots-Server/cahoots51/node_modules/serverless-plugin-sns/index.js:42:20)
    at next (/usr/local/lib/node_modules/serverless/node_modules/rimraf/rimraf.js:74:7)
    at FSReqWrap.CB [as oncomplete] (/usr/local/lib/node_modules/serverless/node_modules/rimraf/rimraf.js:110:9)
From previous event:
    at Serverless._execute (/usr/local/lib/node_modules/serverless/lib/Serverless.js:195:19)
    at Serverless.actions.(anonymous function) (/usr/local/lib/node_modules/serverless/lib/Serverless.js:424:20)
    at Serverless.command (/usr/local/lib/node_modules/serverless/lib/Serverless.js:393:38)
    at /usr/local/lib/node_modules/serverless/bin/serverless:19:16
    at processImmediate [as _immediateCallback] (timers.js:384:17)
From previous event:
    at Object.<anonymous> (/usr/local/lib/node_modules/serverless/bin/serverless:18:4)
    at Module._compile (module.js:399:26)
    at Object.Module._extensions..js (module.js:406:10)
    at Module.load (module.js:345:32)
    at Function.Module._load (module.js:302:12)
    at Function.Module.runMain (module.js:431:10)
    at startup (node.js:141:18)
    at node.js:977:3

```
