### PR TITLE
Treat credentials as a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,12 @@ module.exports = function(S) {
             let _this = this,
                 credentials = S.getProvider('aws').getCredentials(_this.stage, region);
 
-            return credentials.then(function(creds) {
+            return BbPromise.resolve()
+            .then(function() {
+                // Will handle this if it's a promise or an object
+                return credentials;
+            })
+            .then(function(creds) {
                 _this.sns = new AWS.SNS({
                     region: region,
                     accessKeyId: creds.accessKeyId,

--- a/index.js
+++ b/index.js
@@ -60,19 +60,20 @@ module.exports = function(S) {
             let _this = this;
 
             _this.stage = evt.options.stage;
-            _this._initAws(region);
+            _this._initAws(region)
+            .then(function() {
+                if (S.cli.action != 'deploy' || (S.cli.context != 'function' && S.cli.context != 'dash'))
+                    return;
 
-            if (S.cli.action != 'deploy' || (S.cli.context != 'function' && S.cli.context != 'dash'))
-                return;
+                _this.functionSNSSettings = _this._getFunctionsSNSSettings(evt, region);
 
-            _this.functionSNSSettings = _this._getFunctionsSNSSettings(evt, region);
+                // no sns.json found
+                if (_this.functionSNSSettings.length == 0) {
+                    return;
+                }
 
-            // no sns.json found
-            if (_this.functionSNSSettings.length == 0) {
-                return;
-            }
-
-            _this._manageTopics(_this.functionSNSSettings)
+                return _this._manageTopics(_this.functionSNSSettings)
+            })
             .then(function(){
                 let _this = this;
                 _this._bindFunctions(_this.functionSNSSettings);
@@ -236,21 +237,24 @@ module.exports = function(S) {
          */
         _initAws (region) {
             let _this = this,
-                credentials = S.getProvider('aws').getCredentials(_this.stage, region);;
+                credentials = S.getProvider('aws').getCredentials(_this.stage, region);
 
-            _this.sns = new AWS.SNS({
-                region: region,
-                accessKeyId: credentials.accessKeyId,
-                secretAccessKey: credentials.secretAccessKey
-            });
+            return credentials.then(function(creds) {
+                _this.sns = new AWS.SNS({
+                    region: region,
+                    accessKeyId: creds.accessKeyId,
+                    secretAccessKey: creds.secretAccessKey
+                });
 
-            BbPromise.promisifyAll(_this.sns);
+                BbPromise.promisifyAll(_this.sns);
 
-            _this.lambda = new AWS.Lambda({
-                region: region,
-                accessKeyId: credentials.accessKeyId,
-                secretAccessKey: credentials.secretAccessKey
-            });
+                _this.lambda = new AWS.Lambda({
+                    region: region,
+                    accessKeyId: creds.accessKeyId,
+                    secretAccessKey: creds.secretAccessKey
+                });
+            })
+            
         }
 
 


### PR DESCRIPTION
I'm not sure when this changed, but this plugin is failing for me right now on 0.5.5, because `S.getProvider('aws').getCredentials()` returns a Promise rather than an object. So I've altered the code a little to handle either a Promise or an object and it's working again for me now.
